### PR TITLE
use require() instead of import in preload.js

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron/renderer'
+const { contextBridge, ipcRenderer } = require('electron/renderer')
 
 contextBridge.exposeInMainWorld('electronAPI', {
     onUpdateWeather: (callback) => ipcRenderer.on('update-weather', (_event, value) => callback(value)),


### PR DESCRIPTION
See: https://www.electronjs.org/docs/latest/tutorial/esm#sandboxed-preload-scripts-cant-use-esm-imports